### PR TITLE
[FIX] Manage res.partner commercial fields, set Selection fields' ondelete attribute

### DIFF
--- a/account_invoice_base_invoicing_mode/models/res_partner.py
+++ b/account_invoice_base_invoicing_mode/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -13,3 +13,10 @@ class ResPartner(models.Model):
         default=False,
         help="Do not group sale order into one invoice.",
     )
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + [
+            "invoicing_mode",
+            "one_invoice_per_order",
+        ]

--- a/account_invoice_mode_at_shipping/models/res_partner.py
+++ b/account_invoice_mode_at_shipping/models/res_partner.py
@@ -7,4 +7,7 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    invoicing_mode = fields.Selection(selection_add=([("at_shipping", "At Shipping")]))
+    invoicing_mode = fields.Selection(
+        selection_add=[("at_shipping", "At Shipping")],
+        ondelete={"at_shipping": lambda r: r.write({"invoicing_mode": "standard"})},
+    )

--- a/account_invoice_mode_at_shipping/models/stock_picking.py
+++ b/account_invoice_mode_at_shipping/models/stock_picking.py
@@ -15,7 +15,7 @@ class StockPicking(models.Model):
         return res
 
     def _invoice_at_shipping(self):
-        """Check if picking must be invoiced at shippin`g."""
+        """Check if picking must be invoiced at shipping."""
         self.ensure_one()
         return (
             self.picking_type_code == "outgoing"

--- a/account_invoice_mode_monthly/models/res_partner.py
+++ b/account_invoice_mode_monthly/models/res_partner.py
@@ -7,4 +7,7 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    invoicing_mode = fields.Selection(selection_add=([("monthly", "Monthly")]))
+    invoicing_mode = fields.Selection(
+        selection_add=[("monthly", "Monthly")],
+        ondelete={"monthly": lambda r: r.write({"invoicing_mode": "standard"})},
+    )


### PR DESCRIPTION
* Add 'invoicing_mode' and 'one_invoice_per_order' to res.partner's _commercial_fields()
* Properly define 'ondelete' attribute to Selection fields with 'selection_add' attribute
* Fixed typo in docstring

Should make PR [#844](https://github.com/OCA/account-invoicing/pull/844) ready to merge.